### PR TITLE
Updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,74 +2,175 @@
 
 
 [[projects]]
+  digest = "1:4a178cc984da91772ff98dd078699e7707a221986bf8342379567148e1e6d1b6"
   name = "github.com/coreos/go-systemd"
   packages = ["daemon"]
-  revision = "d2196463941895ee908e13531a23a39feb9e1243"
-  version = "v15"
+  pruneopts = ""
+  revision = "2d78030078ef61b3cae27f42ad6d0e46db51b339"
+  version = "v22.0.0"
 
 [[projects]]
+  digest = "1:d69d2ba23955582a64e367ff2b0808cdbd048458c178cea48f11ab8c40bd7aea"
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys"]
-  revision = "100ba4e885062801d56799d78530b73b178a78f3"
-  version = "v0.4"
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys",
+  ]
+  pruneopts = ""
+  revision = "5628607bb4c51c3157aacc3a50f0ab707582b805"
+  version = "v1.3.1"
 
 [[projects]]
-  branch = "master"
+  digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "17ce1425424ab154092bbb43af630bd647f3bb0d"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
+  digest = "1:0f51cee70b0d254dbc93c22666ea2abf211af81c1701a96d04e2284b408621db"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
+
+[[projects]]
+  digest = "1:1a405cddcf3368445051fb70ab465ae99da56ad7be8d8ca7fc52159d1c2d873c"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
-  version = "v1.0.3"
+  pruneopts = ""
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
+  version = "v1.4.2"
 
 [[projects]]
   branch = "master"
-  name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
-  revision = "81e90905daefcd6fd217b62423c0908922eadb30"
-
-[[projects]]
-  branch = "master"
+  digest = "1:bce1fb1dafa615413d845819aa75ba69d0979cdc2ac3b840e1c19c802a737916"
   name = "golang.org/x/net"
-  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "66aacef3dd8a676686c7ae3716979581e8b03c47"
+  packages = [
+    "context",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+  ]
+  pruneopts = ""
+  revision = "6afb5195e5aab057fda82e27171243402346b0ad"
 
 [[projects]]
   branch = "master"
+  digest = "1:942248a6d43ccffca44e245d1ba54441d2f7ad13b70a7f470fd63b28d7851bbe"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
-  revision = "9aade4d3a3b7e6d876cd3823ad20ec45fc035402"
+  packages = ["unix"]
+  pruneopts = ""
+  revision = "e047566fdf82409bf7a52212cf71df83ea2772fb"
 
 [[projects]]
-  branch = "master"
+  digest = "1:740b51a55815493a8d0f2b1e0d0ae48fe48953bf7eaf3fcc4198823bf67768c0"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "bd91bbf73e9a4a801adbfb97133c992678533126"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/language",
+    "internal/language/compact",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:36d4280cd80d6211de553edf1a75f8a2826a18f3dbb0f29adc85a83294f29a63"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "595979c8a7bf586b2d293fb42246bf91a0b893d9"
+  pruneopts = ""
+  revision = "0452cf42e150a6aeb2c8615de02e260ae83d9873"
 
 [[projects]]
+  digest = "1:7af390490e636a6adc9c76b37a3c823195fbf375a02c4d9506b4dd49d5d2409a"
   name = "google.golang.org/grpc"
-  packages = [".","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","stats","status","tap","transport"]
-  revision = "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3"
-  version = "v1.6.0"
+  packages = [
+    ".",
+    "attributes",
+    "backoff",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
+    "codes",
+    "connectivity",
+    "credentials",
+    "credentials/internal",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/balancerload",
+    "internal/binarylog",
+    "internal/buffer",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/resolver/dns",
+    "internal/resolver/passthrough",
+    "internal/syscall",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "serviceconfig",
+    "stats",
+    "status",
+    "tap",
+  ]
+  pruneopts = ""
+  revision = "f5b0812e6fe574d90da76b205e9eb51f6ddb1919"
+  version = "v1.26.0"
 
 [[projects]]
-  name = "k8s.io/kubernetes"
-  packages = ["pkg/kubelet/apis/cri/v1alpha1/runtime"]
-  revision = "17d7182a7ccbb167074be7a87f0a68bd00d58d97"
-  version = "v1.7.5"
+  digest = "1:e50b8bb7be3b934506cc672985302ce3c70809f4216612a08a59c7456f8bf179"
+  name = "k8s.io/cri-api"
+  packages = ["pkg/apis/runtime/v1alpha2"]
+  pruneopts = ""
+  revision = "775aa3c1cf7380ba8b7362f5a52f1e6d2e130bb9"
+  version = "v0.17.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "96d2f41d2adebdbcc092c87d3cb031f3705cdb97325e662efc00f3399be1487a"
+  input-imports = [
+    "github.com/coreos/go-systemd/daemon",
+    "github.com/sirupsen/logrus",
+    "golang.org/x/net/context",
+    "google.golang.org/grpc",
+    "k8s.io/cri-api/pkg/apis/runtime/v1alpha2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/kubernix/kubernix.go
+++ b/cmd/kubernix/kubernix.go
@@ -11,7 +11,7 @@ import (
 	systemdDaemon "github.com/coreos/go-systemd/daemon"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	cri "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	"github.com/moretea/kubernix/server"
 )

--- a/dep.nix
+++ b/dep.nix
@@ -4,13 +4,13 @@ with pkgs;
 rec {
   dep = buildGoPackage rec {
     name = "dep-unstable-${version}";
-    version = "0.3.0";
+    version = "0.5.4";
 
     src = fetchFromGitHub {
       owner = "golang";
       repo = "dep";
       rev = "v${version}";
-      sha256 = "1mkyc2z2zidh5h4vwwwc71cbyyi48c0n8gh2imjxbyy0g5i1vbgm";
+      sha256 = "02akzbjar1v01rdal746vk6mklff29yk2mqfyjk1zrs0mlg38ygd";
     };
 
     goPackagePath = "github.com/golang/dep";

--- a/runtime/sandbox.go
+++ b/runtime/sandbox.go
@@ -1,7 +1,7 @@
 package runtime
 
 import (
-	cri "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 type Container struct {

--- a/server/container.go
+++ b/server/container.go
@@ -43,6 +43,11 @@ func (s *Server) ContainerStatus(ctx context.Context, rq *cri.ContainerStatusReq
 	return nil, fmt.Errorf("not implemented")
 }
 
+// UpdateContainerResources updates the cgroup resources for the container.
+func (s *Server) UpdateContainerResources(ctx context.Context, rq *cri.UpdateContainerResourcesRequest) (*cri.UpdateContainerResourcesResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // ExecSync runs a command in a container synchronously.
 func (s *Server) ExecSync(ctx context.Context, rq *cri.ExecSyncRequest) (*cri.ExecSyncResponse, error) {
 	return nil, fmt.Errorf("not implemented")
@@ -71,5 +76,12 @@ func (s *Server) ContainerStats(ctx context.Context, rq *cri.ContainerStatsReque
 
 // ListContainerStats returns stats of all running containers.
 func (s *Server) ListContainerStats(ctx context.Context, rq *cri.ListContainerStatsRequest) (*cri.ListContainerStatsResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// ReopenContainerLog asks runtime to reopen the stdout/stderr log file
+// for the container. If it returns error, new container log file MUST NOT
+// be created.
+func (s *Server) ReopenContainerLog(ctx context.Context, rq *cri.ReopenContainerLogRequest) (*cri.ReopenContainerLogResponse, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/server/container.go
+++ b/server/container.go
@@ -3,7 +3,7 @@ package server
 import (
 	"fmt"
 	context "golang.org/x/net/context"
-	cri "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // CreateContainer creates a new container in specified PodSandbox

--- a/server/image.go
+++ b/server/image.go
@@ -5,7 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	context "golang.org/x/net/context"
-	cri "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // ListImages lists existing images.

--- a/server/pod_sandbox.go
+++ b/server/pod_sandbox.go
@@ -5,7 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	context "golang.org/x/net/context"
-	cri "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	"github.com/moretea/kubernix/runtime"
 )

--- a/server/runtime.go
+++ b/server/runtime.go
@@ -5,7 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	context "golang.org/x/net/context"
-	cri "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // UpdateRuntimeConfig updates the runtime configuration based on the given request.

--- a/server/status.go
+++ b/server/status.go
@@ -3,7 +3,7 @@ package server
 import (
 	log "github.com/sirupsen/logrus"
 	context "golang.org/x/net/context"
-	cri "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // Status returns the status of the runtime.

--- a/server/version.go
+++ b/server/version.go
@@ -3,7 +3,7 @@ package server
 import (
 	log "github.com/sirupsen/logrus"
 	context "golang.org/x/net/context"
-	cri "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // Version returns the runtime name, runtime version, and runtime API version.

--- a/shell.nix
+++ b/shell.nix
@@ -2,17 +2,18 @@
 with pkgs;
 with (import ./dep.nix { inherit pkgs; });
 let
-  crictl = buildGoPackage {
+  crictl = buildGoPackage rec {
     name = "crictl";
+    version = "1.17.0";
 
     src = fetchFromGitHub {
-      owner = "kubernetes-incubator";
+      owner = "kubernetes-sigs";
       repo = "cri-tools";
-      rev = "e03736e429bcd0dba6f46cf6d6f7ccf0f5c70cc3";
-      sha256= "00zy269k3y3q664gm6lxvr8v2ky8zdgkbxi9banx08irwxcrg22p";
+      rev = "v${version}";
+      sha256= "0h9gry56graif761lmcy91q9fzwvmwb15wcx8245927yfg5j0zgh";
     };
 
-    goPackagePath = "github.com/kubernetes-incubator/cri-tools";
+    goPackagePath = "github.com/kubernetes-sigs/cri-tools";
     subPackages = ["cmd/crictl"];
     deps = null;
   };


### PR DESCRIPTION
Updated versions of dep and cri-tools. cri-tools moved to kubernetes-sigs
Updated to v1alpha2 for cri-api, which moved to `k8s.io/cri-api/pkg/apis/runtime/v1alpha2` from `k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime`
Added two methods to implement the new interface, which just return a not implemented error.